### PR TITLE
게임 밸런스 패치&오류 발견

### DIFF
--- a/Assets/Prefab/NomalBullet1 L.prefab
+++ b/Assets/Prefab/NomalBullet1 L.prefab
@@ -99,7 +99,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9635057838a23e8479d4eabedfda58d7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 3
+  damage: 10
 --- !u!114 &-2532369903625375536
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -113,7 +113,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   speed: 10
-  distance: 0.2
+  distance: 0.5
   isLayer:
     serializedVersion: 2
     m_Bits: 192

--- a/Assets/Prefab/NomalBullet1 R.prefab
+++ b/Assets/Prefab/NomalBullet1 R.prefab
@@ -101,7 +101,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   speed: 10
-  distance: 0.2
+  distance: 0.3
   isLayer:
     serializedVersion: 2
     m_Bits: 192
@@ -117,7 +117,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9635057838a23e8479d4eabedfda58d7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 3
+  damage: 10
 --- !u!58 &8590024688212659422
 CircleCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Prefab/NomalBullet1 U.prefab
+++ b/Assets/Prefab/NomalBullet1 U.prefab
@@ -100,7 +100,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   speed: 10
-  distance: 0.2
+  distance: 0.5
   isLayer:
     serializedVersion: 2
     m_Bits: 192
@@ -116,7 +116,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9635057838a23e8479d4eabedfda58d7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 3
+  damage: 10
 --- !u!58 &2505869456436143666
 CircleCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Prefab/Player/Player.prefab
+++ b/Assets/Prefab/Player/Player.prefab
@@ -150,17 +150,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c0d502539360eeb498f0cc90a0bb9baa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  basicrightattack: {fileID: 317862037724060260, guid: 7483140b7b6ce21438f9fac0b50eb203, type: 3}
-  basicleftattack: {fileID: 317862037724060260, guid: e48b4e47ececdb04ba210a8539fcd189, type: 3}
+  basicrightattack: {fileID: 317862037724060260, guid: e48b4e47ececdb04ba210a8539fcd189, type: 3}
+  basicleftattack: {fileID: 317862037724060260, guid: 7483140b7b6ce21438f9fac0b50eb203, type: 3}
   basicupattack: {fileID: 317862037724060260, guid: 49be6d91e2c3fa24abb52056db08929a, type: 3}
-  Penetrationrightattack: {fileID: 6982617944397340478, guid: 5cdc3ebb8ef4b2c41b3009d922fe220e, type: 3}
-  Penetrationleftattack: {fileID: 6982617944397340478, guid: 2ed1df452962d614294345967302b899, type: 3}
+  Penetrationrightattack: {fileID: 6982617944397340478, guid: 2ed1df452962d614294345967302b899, type: 3}
+  Penetrationleftattack: {fileID: 6982617944397340478, guid: 5cdc3ebb8ef4b2c41b3009d922fe220e, type: 3}
   Penetrationupattack: {fileID: 317862037724060260, guid: aa99fdac08734ea408a097d8e00df645, type: 3}
-  quickfirerightattack: {fileID: 4787299881679389491, guid: 78303ac58cf17944bb98baa24e940b3d, type: 3}
-  quickfireleftattack: {fileID: 4787299881679389491, guid: 5e7120e5a2a08a44f819390e1a24dcfc, type: 3}
+  quickfirerightattack: {fileID: 4787299881679389491, guid: 5e7120e5a2a08a44f819390e1a24dcfc, type: 3}
+  quickfireleftattack: {fileID: 4787299881679389491, guid: 78303ac58cf17944bb98baa24e940b3d, type: 3}
   quickfireupattack: {fileID: 317862037724060260, guid: 98c70f633436bf04abca9300572c92ee, type: 3}
   pos: {x: 0, y: 0, z: 0}
-  cooltime: 0.1
+  cooltime: 1
   curtime: 0
 --- !u!114 &1891866768351531662
 MonoBehaviour:

--- a/Assets/Prefab/PlayerBullet1 L.prefab
+++ b/Assets/Prefab/PlayerBullet1 L.prefab
@@ -99,7 +99,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9635057838a23e8479d4eabedfda58d7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 3
+  damage: 7
 --- !u!114 &-1080221891737664014
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefab/PlayerBullet1 R.prefab
+++ b/Assets/Prefab/PlayerBullet1 R.prefab
@@ -99,7 +99,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9635057838a23e8479d4eabedfda58d7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 3
+  damage: 7
 --- !u!114 &-7216642572614921756
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefab/PlayerBullet1 U.prefab
+++ b/Assets/Prefab/PlayerBullet1 U.prefab
@@ -99,7 +99,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9635057838a23e8479d4eabedfda58d7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 3
+  damage: 7
 --- !u!114 &8259286824263222833
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefab/PlayerBullet2 L.prefab
+++ b/Assets/Prefab/PlayerBullet2 L.prefab
@@ -99,7 +99,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9635057838a23e8479d4eabedfda58d7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 7
+  damage: 16
 --- !u!114 &-6384201912176421592
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefab/PlayerBullet2 R.prefab
+++ b/Assets/Prefab/PlayerBullet2 R.prefab
@@ -99,7 +99,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9635057838a23e8479d4eabedfda58d7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 7
+  damage: 16
 --- !u!114 &-4743138902085252099
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefab/PlayerBullet2 U.prefab
+++ b/Assets/Prefab/PlayerBullet2 U.prefab
@@ -99,7 +99,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9635057838a23e8479d4eabedfda58d7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  damage: 7
+  damage: 16
 --- !u!114 &-3824486064309831959
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Script/UI&Data/GameManager.cs
+++ b/Assets/Script/UI&Data/GameManager.cs
@@ -13,12 +13,12 @@ public class GameManager : MonoBehaviour
     double MaxHp; //최대체력
     public static double enemyHP = 100; //잡몹 체력 플레이어와 동일하다
     public static double MaxenemyHP = 100; //잡몹 체력 플레이어와 동일하다
-    public static double summonenemyHP = 30; //중간보스 소환 잡몹 체력 플레이어보다 낮다
-    public static double summonMaxenemyHP = 30; //중간보스 소환 잡몹 체력 플레이어보다 낮다
-    public static double MidBossHP = 200; //중간보스 체력 플레이어 보다 큼 임의설정
-    public static double MaxMidBossHP = 200; //중간보스 체력 플레이어 보다 큼 임의설정
-    public static double BossHP = 500; //중간보스 체력 플레이어 보다 큼 임의설정
-    public static double MaxBossHP = 500; //중간보스 체력 플레이어 보다 큼 임의설정
+    public static double summonenemyHP = 50; //중간보스 소환 잡몹 체력 플레이어보다 낮다
+    public static double summonMaxenemyHP = 50; //중간보스 소환 잡몹 체력 플레이어보다 낮다
+    public static double MidBossHP = 500; //중간보스 체력 플레이어 보다 큼 임의설정
+    public static double MaxMidBossHP = 500; //중간보스 체력 플레이어 보다 큼 임의설정
+    public static double BossHP = 800; //중간보스 체력 플레이어 보다 큼 임의설정
+    public static double MaxBossHP = 800; //중간보스 체력 플레이어 보다 큼 임의설정
 
     //공격한 적이 누구인가
     private bool isEnemyHit = false;

--- a/Assets/Script/player/playerattack.cs
+++ b/Assets/Script/player/playerattack.cs
@@ -57,13 +57,13 @@ public class playerattack : MonoBehaviour
         {
             if (atktype == 0) //기본총알
             {
-                if (Input.GetKey(KeyCode.A)) //오른쪽으로 공격
-                {
-                    Instantiate(basicrightattack, pos, transform.rotation);
-                }
-                else if (Input.GetKey(KeyCode.D))   //왼쪽으로 공격
+                if (Input.GetKey(KeyCode.A)) //왼쪽으로 공격
                 {
                     Instantiate(basicleftattack, pos, transform.rotation);
+                }
+                else if (Input.GetKey(KeyCode.D))   //오른쪽으로 공격
+                {
+                    Instantiate(basicrightattack, pos, transform.rotation);
                 }
                 else if (Input.GetKey(KeyCode.W))   //위로 공격
                 {
@@ -73,13 +73,13 @@ public class playerattack : MonoBehaviour
             }
             if (atktype == 1) //관통총알
             {
-                if (Input.GetKey(KeyCode.A)) //오른쪽으로 공격
-                {
-                    Instantiate(Penetrationrightattack, pos, transform.rotation);
-                }
-                else if (Input.GetKey(KeyCode.D))   //왼쪽으로 공격
+                if (Input.GetKey(KeyCode.A)) //왼쪽으로 공격
                 {
                     Instantiate(Penetrationleftattack, pos, transform.rotation);
+                }
+                else if (Input.GetKey(KeyCode.D))   //오른쪽으로 공격
+                {
+                    Instantiate(Penetrationrightattack, pos, transform.rotation);
                 }
                 else if (Input.GetKey(KeyCode.W))   //위로 공격
                 {
@@ -89,17 +89,17 @@ public class playerattack : MonoBehaviour
             }
             if (atktype == 2) //속사총알
             {
-                if (Input.GetKey(KeyCode.A)) //오른쪽으로 공격
-                {
-                    quickfireR();
-                    Invoke("quickfireR", 0.15f);
-                    Invoke("quickfireR", 0.3f);
-                }
-                else if (Input.GetKey(KeyCode.D))   //왼쪽으로 공격
+                if (Input.GetKey(KeyCode.A)) //왼쪽으로 공격
                 {
                     quickfireL();
                     Invoke("quickfireL", 0.15f);
                     Invoke("quickfireL", 0.3f);
+                }
+                else if (Input.GetKey(KeyCode.D))   //오른쪽으로 공격
+                {
+                    quickfireR();
+                    Invoke("quickfireR", 0.15f);
+                    Invoke("quickfireR", 0.3f);
                 }
                 else if (Input.GetKey(KeyCode.W))   //위로 공격
                 {


### PR DESCRIPTION
플레이어 공격 스크립트 오류 수정
왼쪽 공격과 오른쪽공격이 반대였던것을 다시 제대로 수정

개임 밸런스 패치
초반 스테이지에 공격속도 도 느리고 데미지도 약해
1스테이지 잡몹을 잡는데 시간이 오래 소요됨
총알 데미지를 10으로 높여 10대 때리면 죽게 수정
다른 업그레이드 총알도 데미지 를 높임
기본 총알 데미지 10
관통 총알 데미지 16
속사 총알 데미지 7 * 3
중간보스의 체력, 중간보스가소환하는잡몹, 보스의 체력도 높여줌
소환 잡몹 30 -> 50
중간 보스 200 -> 500
보스 500 -> 800 

찾은 오류
스테이지 를 넘어가거나 스테이지도중
소환한 잡몹들이 체력이
이전 잡몹 체력을 따라간다
처음 스테이지에서 잡몹을 잡으면
다음스테이지의 잡몹의 체력이 0
중간보스 가 소환한 잡몹도 마찬가지